### PR TITLE
Using shared array pool for byte allocation

### DIFF
--- a/Setup/fo-dicom.Codecs.nuspec
+++ b/Setup/fo-dicom.Codecs.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>fo-dicom.Codecs</id>
-        <version>5.10.9.0-beta3</version>
+        <version>5.10.9.2.private</version>
         <title>fo-dicom Codecs</title>
         <authors>Efferent-Health,fo-dicom</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>

--- a/Setup/fo-dicom.Codecs.nuspec
+++ b/Setup/fo-dicom.Codecs.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>fo-dicom.Codecs</id>
-        <version>5.10.9.2.private</version>
+        <version>5.10.9.2-private</version>
         <title>fo-dicom Codecs</title>
         <authors>Efferent-Health,fo-dicom</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>


### PR DESCRIPTION
Description:

Using ArrayPool.Shared instead of creating a new byte[] every time to be more efficient on

Reduced Garbage Collection (GC) Pressure
Less Memory Fragmentation
Faster Allocation
Testing
Ran unit and acceptance tests.